### PR TITLE
Add known issue with Kuryr Neutron ports

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -703,6 +703,13 @@ $ operator-sdk new <operator_name> --type=helm \
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874754[*BZ#1874754*])
 
+* When running on OpenStack with Kuryr, unnecessary Neutron Ports will get
+created for each `hostNetworking` pod. The ports are safe to be deleted and
+automatic deletion will be implemented in one of the z-stream releases of
+{product-title} 4.6.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1888318[*BZ#1888318*])
+
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates
 

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -703,10 +703,10 @@ $ operator-sdk new <operator_name> --type=helm \
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874754[*BZ#1874754*])
 
-* When running on OpenStack with Kuryr, unnecessary Neutron Ports will get
-created for each `hostNetworking` pod. The ports are safe to be deleted and
-automatic deletion will be implemented in one of the z-stream releases of
-{product-title} 4.6.
+* Clusters that run on {rh-openstack} and use Kuryr create unnecessary Neutron ports
+for each `hostNetworking` pod. You can delete these ports safely.
+Automatic port deletion is planned for a future release of
+{product-title}.
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1888318[*BZ#1888318*])
 


### PR DESCRIPTION
Kuryr creates unnecessary Neutron Ports for hostNetworking pods and we
won't fix it before GA. This is adding info about the issue.