### PR TITLE
OSDOCS-5240 #57427: review rendered page with important fixes on the structure

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -121,8 +121,6 @@ include::modules/install-creating-install-config-aws-local-zones.adoc[leveloffse
 // Verify removal due to automation.
 // include::modules/installation-localzone-generate-k8s-manifest.adoc[leveloffset=+2]
 
-//[role="_additional-resources"]
-//.Additional resources
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -67,13 +67,13 @@ include::modules/cluster-limitations-local-zone.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-aws-add-local-zone-locations.adoc[leveloffset=+1]
-
 include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-creating-aws-vpc-localzone.adoc[leveloffset=+1]
 
 include::modules/installation-cloudformation-vpc-localzone.adoc[leveloffset=+2]
+
+include::modules/installation-aws-add-local-zone-locations.adoc[leveloffset=+1]
 
 include::modules/installation-creating-aws-subnet-localzone.adoc[leveloffset=+1]
 
@@ -98,8 +98,16 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 * See link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Local Zones features] in the AWS documentation for more information about AWS Local Zones and the supported instances types and services. 
 
 include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
+// Suggest to standarize edge-pool's specific files with same prefixes, like: machine-edge-pool-[...] or compute-edge-pool-[...] (which is more compatible with install-config.yaml/compute)
 include::modules/machines-edge-machine-pool.adoc[leveloffset=+2]
 include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[Changing the MTU for the cluster network]
+* xref:../../networking/changing-cluster-network-mtu.adoc#nw-ovn-ipsec-enable_configuring-ipsec-ovn[Enabling IPsec encryption]
+
 include::modules/install-creating-install-config-aws-local-zones.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -113,11 +121,8 @@ include::modules/install-creating-install-config-aws-local-zones.adoc[leveloffse
 // Verify removal due to automation.
 // include::modules/installation-localzone-generate-k8s-manifest.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[Changing the MTU for the cluster network]
-* xref:../../networking/changing-cluster-network-mtu.adoc#nw-ovn-ipsec-enable_configuring-ipsec-ovn[Enabling IPsec encryption]
+//[role="_additional-resources"]
+//.Additional resources
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
@@ -132,6 +137,8 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
 * See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
 
+include::modules/machine-edge-pool-review-nodes.adoc[leveloffset=+1]
+
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -142,6 +149,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 [id="installing-aws-localzone-next-steps"]
 == Next steps
 
+* xref:../../post_installation_configuration/cluster-tasks.adoc#installation-extend-edge-nodes-aws-local-zones_post-install-cluster-tasks[Creating user workloads in AWS Local Zones].
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/modules/edge-machine-pools-aws-local-zones.adoc
+++ b/modules/edge-machine-pools-aws-local-zones.adoc
@@ -4,5 +4,20 @@
 
 Edge worker nodes are tainted worker nodes that run in AWS Local Zones locations.
 
+There are some important information when deploying a cluster using Local Zones:
+
 * Amazon EC2 instances in the Local Zones are more expensive than Amazon EC2 instances in the Availability Zones
 * Latency between applications and end users are lower in Local Zones, and it may vary by location. There is a latency impact for some workloads if, for example, routers are mixed between Local Zones and Availability Zones.
+* The cluster-network Maximum Transmission Unit (MTU) is adjusted automatically to the lower restricted by AWS when Local Zone subnets are detected on the `install-config.yaml`, according to the network plugin.
+
++
+[IMPORTANT]
+====
+Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+The cluster network MTU must be always less than the EC2 MTU to account for the overhead. The specific overhead is determined by the network plugin, for example:
+
+- OVN-Kubernetes: `100 bytes`
+- OpenShift SDN: `50 bytes`
+
+The network plugin could provide additional features, like IPsec, that also must be decreased the MTU. Check the documentation for additional information.
+====

--- a/modules/edge-machine-pools-aws-local-zones.adoc
+++ b/modules/edge-machine-pools-aws-local-zones.adoc
@@ -4,7 +4,7 @@
 
 Edge worker nodes are tainted worker nodes that run in AWS Local Zones locations.
 
-There are some important information when deploying a cluster using Local Zones:
+When deploying a cluster that uses Local Zones:
 
 * Amazon EC2 instances in the Local Zones are more expensive than Amazon EC2 instances in the Availability Zones
 * Latency between applications and end users are lower in Local Zones, and it may vary by location. There is a latency impact for some workloads if, for example, routers are mixed between Local Zones and Availability Zones.

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -23,16 +23,15 @@ Parameters:
     Description: VPC Id
     Type: String
   ZoneName:
-    Description: Local Zone Name (Example us-west-2-lax-1a)
+    Description: Local Zone Name (Example us-east-1-nyc-1a)
     Type: String
   SubnetName:
-    Description: Local Zone Name (Example cluster-usw2-lax-1a)
+    Description: Local Zone Name (Example cluster-public-us-east-1-nyc-1a)
     Type: String
   PublicRouteTableId:
     Description: Public Route Table ID to associate the Local Zone subnet
     Type: String
   PublicSubnetCidr:
-    # yamllint disable-line rule:line-length
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.128.0/20

--- a/modules/installation-cloudformation-vpc-localzone.adoc
+++ b/modules/installation-cloudformation-vpc-localzone.adoc
@@ -4,10 +4,10 @@
 
 :_content-type: REFERENCE
 [id="installation-cloudformation-vpc-localzone_{context}"]
-= CloudFormation template for the VPC that uses AWS Local Zones
+= CloudFormation template for the VPC
 
 You can use the following CloudFormation template to deploy the VPC that
-you need for your {product-title} cluster that uses AWS Local Zones.
+you need for your {product-title} cluster.
 
 .CloudFormation template for the VPC
 [%collapsible]

--- a/modules/installation-creating-aws-subnet-localzone.adoc
+++ b/modules/installation-creating-aws-subnet-localzone.adoc
@@ -52,13 +52,13 @@ requires:
   }
 ]
 ----
-<1> Specify the VPC ID, output variable `VpcId` of the CloudFormation stack
+<1> Specify the VPC ID, which is the value `VpcID` in the output of the CloudFormation template.
 for the VPC.
-<2> Specify the Route Table ID, output variable `PublicRouteTableId` of the CloudFormation stack
+<2> Specify the Route Table ID, which is the value of the `PublicRouteTableId` in the CloudFormation stack
 for the VPC.
-<3> Specify the AWS Local Zone name, output variable `ZoneName` of command `aws ec2 describe-availability-zones`
-executed on the section "Opting into AWS Local Zones".
-<4> Specify a CIDR block used to create the Local Zone subnet, must be part of the VPC CIDR block `VpcCidr`.
+```suggestion
+<3> Specify the AWS Local Zone name, which is the value of the `ZoneName` field in the `AvailabilityZones` object that you retrieve in the section "Opting into AWS Local Zones".
+<4> Specify a CIDR block that is used to create the Local Zone subnet. This block must be part of the VPC CIDR block `VpcCidr`.
 
 . Copy the template from the *CloudFormation template for the subnet*
 section of this topic and save it as a YAML file on your computer. This template

--- a/modules/installation-creating-aws-subnet-localzone.adoc
+++ b/modules/installation-creating-aws-subnet-localzone.adoc
@@ -35,42 +35,30 @@ requires:
 ----
 [
   {
-    "ParameterKey": "VpcId", <3>
-    "ParameterValue": "vpc-<random_string>" <4>
+    "ParameterKey": "VpcId",
+    "ParameterValue": "<value_of_VpcId>" <1>
   },
   {
-    "ParameterKey": "PublicRouteTableId", <5>
-    "ParameterValue": "<vpc_rtb_pub>" <6>
+    "ParameterKey": "PublicRouteTableId",
+    "ParameterValue": "<value_of_PublicRouteTableId>" <2>
   },
   {
-    "ParameterKey": "LocalZoneName", <7>
-    "ParameterValue": "<cluster_region_name>-<location_identifier>-<zone_identifier>" <8>
+    "ParameterKey": "LocalZoneName",
+    "ParameterValue": "<value_of_GroupName>" <3>
   },
   {
-    "ParameterKey": "LocalZoneNameShort", <9>
-    "ParameterValue": "<lz_zone_shortname>" <10>
-  },
-  {
-    "ParameterKey": "PublicSubnetCidr", <11>
-    "ParameterValue": "10.0.128.0/20" <12>
+    "ParameterKey": "PublicSubnetCidr",
+    "ParameterValue": "10.0.192.0/20" <4>
   }
 ]
 ----
-<1> Specify the cluster name that you used when you generated the `install-config.yaml` file for the cluster.
-<2> The VPC ID in which the Local Zone's subnet will be created.
-<3> Specify the `VpcId` value from the output of the CloudFormation template
+<1> Specify the VPC ID, output variable `VpcId` of the CloudFormation stack
 for the VPC.
-<4> The Public Route Table ID for the VPC.
-<5> Specify the `PublicRouteTableId` value from the output of the CloudFormation template for the VPC.
-<6>  The Local Zone name that the VPC belongs to.
-<7> Specify the Local Zone that you opted your AWS account into, such as `us-east-1-nyc-1a`.
-<8> The shortname of the AWS Local Zone that the VPC belongs to. This name must match the pattern `N[a-z]`.
-<9> Specify a short name for the AWS Local Zone that you opted your AWS account into, such as `<zone_group_identified><zone_identifier>`. For example, `us-east-1-nyc-1a` is shortened to `nyc-1a`.
-//How do we determine this shortname?
-<10> The CIDR block to allow access to the Local Zone.
-<11> Specify a CIDR block in the format `x.x.x.x/16-24`.
-//How do we know what this CIDR is?
-
+<2> Specify the Route Table ID, output variable `PublicRouteTableId` of the CloudFormation stack
+for the VPC.
+<3> Specify the AWS Local Zone name, output variable `ZoneName` of command `aws ec2 describe-availability-zones`
+executed on the section "Opting into AWS Local Zones".
+<4> Specify a CIDR block used to create the Local Zone subnet, must be part of the VPC CIDR block `VpcCidr`.
 
 . Copy the template from the *CloudFormation template for the subnet*
 section of this topic and save it as a YAML file on your computer. This template
@@ -99,7 +87,7 @@ parameters JSON file.
 .Example output
 [source,terminal]
 ----
-arn:aws:cloudformation:us-east-1:123456789012:stack/cluster-lz-nyc1/dbedae40-2fd3-11eb-820e-12a48460849f
+arn:aws:cloudformation:us-east-1:123456789012:stack/<subnet_stack_name>/dbedae40-2fd3-11eb-820e-12a48460849f
 ----
 
 . Confirm that the template components exist by running the following command:

--- a/modules/installation-creating-aws-vpc-localzone.adoc
+++ b/modules/installation-creating-aws-vpc-localzone.adoc
@@ -35,32 +35,25 @@ requires:
 ----
 [
   {
-    "ParameterKey": "ClusterName", <1>
-    "ParameterValue": "mycluster" <2>
+    "ParameterKey": "VpcCidr", <1>
+    "ParameterValue": "10.0.0.0/16" <2>
   },
   {
-    "ParameterKey": "VpcCidr", <3>
-    "ParameterValue": "10.0.0.0/16" <4>
+    "ParameterKey": "AvailabilityZoneCount", <3>
+    "ParameterValue": "3" <4>
   },
   {
-    "ParameterKey": "AvailabilityZoneCount", <5>
-    "ParameterValue": "3" <6>
-  },
-  {
-    "ParameterKey": "SubnetBits", <7>
-    "ParameterValue": "12" <8>
+    "ParameterKey": "SubnetBits", <5>
+    "ParameterValue": "12" <6>
   }
 ]
 ----
-<1> A short, representative cluster name to use for hostnames, etc.
-<2> Specify the cluster name that you used when you generated the
-`install-config.yaml` file for the cluster.
-<3> The CIDR block for the VPC.
-<4> Specify a CIDR block in the format `x.x.x.x/16-24`.
-<5> The number of availability zones to deploy the VPC in.
-<6> Specify an integer between `1` and `3`.
-<7> The size of each subnet in each availability zone.
-<8> Specify an integer between  `5` and `13`, where `5` is `/27` and `13` is `/19`.
+<1> The CIDR block for the VPC.
+<2> Specify a CIDR block in the format `x.x.x.x/16-24`.
+<3> The number of availability zones to deploy the VPC in.
+<4> Specify an integer between `1` and `3`.
+<5> The size of each subnet in each availability zone.
+<6> Specify an integer between  `5` and `13`, where `5` is `/27` and `13` is `/19`.
 
 . Copy the template from the *CloudFormation template for the VPC*
 section of this topic and save it as a YAML file on your computer. This template

--- a/modules/machine-edge-pool-review-nodes.adoc
+++ b/modules/machine-edge-pool-review-nodes.adoc
@@ -1,0 +1,42 @@
+
+:_content-type: CONCEPT
+[id="machine-edge-pool-review-nodes_{context}"]
+= Check nodes created with edge compute pool
+
+After your cluster have been installed successfully, you can check the Machine created by Machine Set added on install time.
+
+. Check the Machine Sets created from the subnet added to install-config.yaml:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api --show-labels
+NAME                                  DESIRED   CURRENT   READY   AVAILABLE   AGE    LABELS
+cluster-7xw5g-edge-us-east-1-nyc-1a   1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
+cluster-7xw5g-worker-us-east-1a       1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
+cluster-7xw5g-worker-us-east-1b       1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
+cluster-7xw5g-worker-us-east-1c       1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
+----
+
+. Check the Machines created from the Machine Sets:
++
+[source,terminal]
+----
+$ oc get machines -n openshift-machine-api 
+NAME                                        PHASE     TYPE          REGION      ZONE               AGE
+cluster-7xw5g-edge-us-east-1-nyc-1a-wbclh   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   3h
+cluster-7xw5g-master-0                      Running   m6i.xlarge    us-east-1   us-east-1a         3h4m
+cluster-7xw5g-master-1                      Running   m6i.xlarge    us-east-1   us-east-1b         3h4m
+cluster-7xw5g-master-2                      Running   m6i.xlarge    us-east-1   us-east-1c         3h4m
+cluster-7xw5g-worker-us-east-1a-rtp45       Running   m6i.xlarge    us-east-1   us-east-1a         3h
+cluster-7xw5g-worker-us-east-1b-glm7c       Running   m6i.xlarge    us-east-1   us-east-1b         3h
+cluster-7xw5g-worker-us-east-1c-qfvz4       Running   m6i.xlarge    us-east-1   us-east-1c         3h
+----
+
+. Check nodes with edge roles:
++
+[source,terminal]
+----
+$ oc get nodes -l node-role.kubernetes.io/edge
+NAME                           STATUS   ROLES         AGE    VERSION
+ip-10-0-207-188.ec2.internal   Ready    edge,worker   172m   v1.25.2+d2e245f
+----

--- a/modules/machine-edge-pool-review-nodes.adoc
+++ b/modules/machine-edge-pool-review-nodes.adoc
@@ -1,15 +1,20 @@
 
-:_content-type: CONCEPT
+:_content-type: PROCEDURE
 [id="machine-edge-pool-review-nodes_{context}"]
-= Check nodes created with edge compute pool
+= Verifying nodes that were created with edge compute pool
 
 After your cluster have been installed successfully, you can check the Machine created by Machine Set added on install time.
 
-. Check the Machine Sets created from the subnet added to install-config.yaml:
+. To check the machine sets created from the subnet you added to the `install-config.yaml` file, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get machineset -n openshift-machine-api --show-labels
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                  DESIRED   CURRENT   READY   AVAILABLE   AGE    LABELS
 cluster-7xw5g-edge-us-east-1-nyc-1a   1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
 cluster-7xw5g-worker-us-east-1a       1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
@@ -17,11 +22,15 @@ cluster-7xw5g-worker-us-east-1b       1         1         1       1           3h
 cluster-7xw5g-worker-us-east-1c       1         1         1       1           3h4m   machine.openshift.io/cluster-api-cluster=cluster-7xw5g
 ----
 
-. Check the Machines created from the Machine Sets:
+. To check the machines that were created from the machine sets, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get machines -n openshift-machine-api 
+----
++
+.Example output
+----
 NAME                                        PHASE     TYPE          REGION      ZONE               AGE
 cluster-7xw5g-edge-us-east-1-nyc-1a-wbclh   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   3h
 cluster-7xw5g-master-0                      Running   m6i.xlarge    us-east-1   us-east-1a         3h4m
@@ -32,11 +41,16 @@ cluster-7xw5g-worker-us-east-1b-glm7c       Running   m6i.xlarge    us-east-1   
 cluster-7xw5g-worker-us-east-1c-qfvz4       Running   m6i.xlarge    us-east-1   us-east-1c         3h
 ----
 
-. Check nodes with edge roles:
+. To check nodes with edge roles, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get nodes -l node-role.kubernetes.io/edge
+----
++
+.Example output
+[source,terminal]
+----
 NAME                           STATUS   ROLES         AGE    VERSION
 ip-10-0-207-188.ec2.internal   Ready    edge,worker   172m   v1.25.2+d2e245f
 ----

--- a/modules/machine-edge-pool-review-nodes.adoc
+++ b/modules/machine-edge-pool-review-nodes.adoc
@@ -3,7 +3,7 @@
 [id="machine-edge-pool-review-nodes_{context}"]
 = Verifying nodes that were created with edge compute pool
 
-After your cluster have been installed successfully, you can check the Machine created by Machine Set added on install time.
+After your install a cluster that uses AWS Local Zones, check the status of the machine that was created by the machine set manifests created at install time.
 
 . To check the machine sets created from the subnet you added to the `install-config.yaml` file, enter the following command:
 +

--- a/modules/machines-edge-machine-pool.adoc
+++ b/modules/machines-edge-machine-pool.adoc
@@ -1,7 +1,7 @@
 
 :_content-type: CONCEPT
 [id="machines-edge-machine-pool_{context}"]
-= The edge compute pool
+= The edge compute pool for AWS Local Zones
 
 {product-title} 4.12 introduced a new compute pool, _edge_, that is designed for use in remote zones. The edge compute pool configuration is common between AWS Local Zone locations. However, due to the type and size limitations of resources like EC2 and EBS on Local Zone resources, the default instance type that is created can vary from the traditional worker pool.
 


### PR DESCRIPTION
Review of https://github.com/openshift/openshift-docs/pull/57427:

- Reordering sections
- suggestions to review the file names
- fixes identified from the preview page https://57427--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html
- adding module `machine-edge-pool-review-nodes.adoc` with a quick overview of the nodes after installation (helping user to understand what is delivered by the feature)
- adding a helper page to deploy user workload on the "Next Steps"

Notes:
- The fixes on CloudFormation and helpers present on 4.12 are super important to be backported, let's track it when we are ok with the final version of OSDOCS-5240 